### PR TITLE
Fixes to LZ4 filter

### DIFF
--- a/LZ4/src/H5Zlz4.c
+++ b/LZ4/src/H5Zlz4.c
@@ -11,9 +11,15 @@
 #include <stdio.h>
 #if defined(_WIN32)
 #include <Winsock2.h>
+#else
+#include <arpa/inet.h>
 #endif
 #include <H5PLextern.h>
 #include <lz4.h>
+#include "lz4_h5filter.h"
+
+#define PUSH_ERR(func, minor, str)                                      \
+    H5Epush1(__FILE__, func, __LINE__, H5E_PLINE, minor, str)
 
 static size_t H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts,
         const unsigned int cd_values[], size_t nbytes,
@@ -46,9 +52,6 @@ const H5Z_class2_t H5Z_LZ4[1] = {{
         (H5Z_func_t)H5Z_filter_lz4,         /* The actual filter function   */
 }};
 
-H5PL_type_t   H5PLget_plugin_type(void) {return H5PL_TYPE_FILTER;}
-const void *H5PLget_plugin_info(void) {return H5Z_LZ4;}
-
 static size_t H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts,
         const unsigned int cd_values[], size_t nbytes,
         size_t *buf_size, void **buf)
@@ -73,9 +76,9 @@ static size_t H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts,
         if(blockSize>origSize)
             blockSize = origSize;
 
-        if (NULL==(outBuf = malloc(origSize)))
+        if (NULL==(outBuf = H5allocate_memory(origSize, false)))
         {
-            printf("cannot malloc\n");
+            printf("error calling H5allocate_memory\n");
             goto error;
         }
         roBuf = (char*)outBuf;   /* pointer to current write position */
@@ -112,7 +115,7 @@ static size_t H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts,
             roBuf += blockSize;            /* advance the write pointer */
             decompSize += blockSize;
         }
-        free(*buf);
+        H5free_memory(*buf);
         *buf = outBuf;
         outBuf = NULL;
         ret_value = (size_t)origSize;  // should always work, as orig_size cannot be > 2GB (sizeof(size_t) < 4GB)
@@ -125,6 +128,7 @@ static size_t H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts,
         size_t block;
         uint64_t *i64Buf;
         uint32_t *i32Buf;
+        size_t maxDestSize;
         char *rpos;      /* pointer to current read position */
         char *roBuf;    /* pointer to current write position */
 
@@ -147,8 +151,9 @@ static size_t H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts,
             blockSize = nbytes;
         }
         nBlocks = (nbytes-1)/blockSize +1;
-        if (NULL==(outBuf = malloc(LZ4_COMPRESSBOUND(nbytes)
-                + 4+8 + nBlocks*4)))
+        maxDestSize = LZ4_compressBound(nbytes) + 4 + 8 + nBlocks*4;
+        outBuf = H5allocate_memory(maxDestSize, false);
+        if (NULL == outBuf)
         {
             goto error;
         }
@@ -174,7 +179,7 @@ static size_t H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts,
                 blockSize = nbytes - origWritten;
 
 #if LZ4_VERSION_NUMBER > 10300
-            compBlockSize = LZ4_compress_default(rpos, roBuf+4,blockSize,nBlocks*4); /// reserve space for compBlockSize
+            compBlockSize = LZ4_compress_default(rpos, roBuf+4,blockSize, maxDestSize-outSize); /// reserve space for compBlockSize
 #else
             compBlockSize = LZ4_compress(rpos, roBuf+4, blockSize); /// reserve space for compBlockSize
 #endif
@@ -195,22 +200,34 @@ static size_t H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts,
             outSize += compBlockSize + 4;
         }
 
-        free(*buf);
+        H5free_memory(*buf);
         *buf = outBuf;
         *buf_size = outSize;
         outBuf = NULL;
         ret_value = outSize;
 
     }
-    done:
+    /* done: */
     if(outBuf)
-        free(outBuf);
+        H5free_memory(outBuf);
     return ret_value;
 
 
     error:
     if(outBuf)
-        free(outBuf);
+        H5free_memory(outBuf);
     outBuf = NULL;
     return 0;
+}
+
+int lz4_register_h5filter(void){
+
+    int retval;
+
+    retval = H5Zregister(H5Z_LZ4);
+    if(retval<0){
+        PUSH_ERR("lz4_register_h5filter",
+                 H5E_CANTREGISTER, "Can't register lz4 filter");
+    }
+    return retval;
 }

--- a/LZ4/src/lz4_h5filter.h
+++ b/LZ4/src/lz4_h5filter.h
@@ -1,0 +1,41 @@
+/*
+ * LZ4 HDF5 filter
+ *
+ * Header File
+ *
+ * Filter Options
+ * --------------
+ *  block_size (option slot 0) : interger (optional)
+ *      What block size to use. Default is 0,
+ *      for which lz4 will pick a block size.
+ *  number_of_threads (option slot 1) : Not currently implemented
+ *
+ *      The compressed format of the data is described in
+ *      http://www.hdfgroup.org/services/filters/HDF5_LZ4.pdf.
+ *
+ */
+
+
+#ifndef LZ4_H5FILTER_H
+#define LZ5_H5FILTER_H
+
+#define H5Z_class_t_vers 2
+#include "hdf5.h"
+
+#define H5Z_FILTER_LZ4 32004
+
+
+H5_DLLVAR const H5Z_class2_t H5Z_LZ4[1];
+
+/* ---- lz4_register_h5filter ----
+ *
+ * Register the LZ4 HDF5 filter within the HDF5 library.
+ *
+ * Call this before using the bitshuffle HDF5 filter from C unless
+ * using dynamically loaded filters.
+ *
+ */
+int lz4_register_h5filter(void);
+
+
+#endif // LZ4_H5FILTER_H

--- a/LZ4/src/lz4_h5plugin.c
+++ b/LZ4/src/lz4_h5plugin.c
@@ -1,0 +1,12 @@
+/*
+ * Dynamically loaded filter plugin for HDF5 LZ4 filter.
+ *
+ *
+ */
+
+
+#include "lz4_h5filter.h"
+#include "H5PLextern.h"
+
+H5PL_type_t H5PLget_plugin_type(void) {return H5PL_TYPE_FILTER;}
+const void *H5PLget_plugin_info(void) {return H5Z_LZ4;}


### PR DESCRIPTION
 - Use H5allocate_memory() and H5free() rather than malloc() and free()
      This is the correct thing to do according to the HDF5 group
- Moved the H5PLget_plugin* definitions into lz4_h5plugin.c.
      This is needed in some cases when building multiple libraries, and
      it is consistent with how most other HDF5 filter plugins are written.
- Changes to work with recent LZ4; the original call to LZ4_compress_default seems incorrect,
      final argument should be remaining size in output buffer
- Added function lz4_register_h5filter(), needed to register filter.
- Added lz5_h5filter.h header file, needed to fefine lz4_register_h5filter().
