### PR TITLE
Add missing license file for bitshuffle code

### DIFF
--- a/bitshuffle/LICENSE
+++ b/bitshuffle/LICENSE
@@ -1,0 +1,21 @@
+Bitshuffle - Filter for improving compression of typed binary data.
+
+Copyright (c) 2014 Kiyoshi Masui (kiyo@physics.ubc.ca)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
The source code in the `/bitshuffle/` directory refers to a license file, but that is missing:
https://github.com/nexusformat/HDF5-External-Filter-Plugins/blob/cabe5fd0aa3402bb742016a68acfc1def63210bd/bitshuffle/src/bitshuffle.c#L8
Distributing the source code without the license file is a violation of that license:

I therefore propose copying the [file from referenced original source repository](https://github.com/kiyo-masui/bitshuffle/blob/9231014a57a6a2b661ac94068e745033048fb477/LICENSE) into the `/bitshuffle/` path.