### PR TITLE
Fix filter not compressing with LZ4 version>1.3.0

### DIFF
--- a/LZ4/src/H5Zlz4.c
+++ b/LZ4/src/H5Zlz4.c
@@ -151,7 +151,7 @@ static size_t H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts,
             blockSize = nbytes;
         }
         nBlocks = (nbytes-1)/blockSize +1;
-        maxDestSize = LZ4_compressBound(nbytes) + 4 + 8 + nBlocks*4;
+        maxDestSize = nBlocks * LZ4_compressBound(blockSize) + 4 + 8 + nBlocks*4;
         outBuf = H5allocate_memory(maxDestSize, false);
         if (NULL == outBuf)
         {
@@ -179,7 +179,7 @@ static size_t H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts,
                 blockSize = nbytes - origWritten;
 
 #if LZ4_VERSION_NUMBER > 10300
-            compBlockSize = LZ4_compress_default(rpos, roBuf+4,blockSize, maxDestSize-outSize); /// reserve space for compBlockSize
+            compBlockSize = LZ4_compress_default(rpos, roBuf+4, blockSize, LZ4_compressBound(blockSize)); /// reserve space for compBlockSize
 #else
             compBlockSize = LZ4_compress(rpos, roBuf+4, blockSize); /// reserve space for compBlockSize
 #endif


### PR DESCRIPTION
This PR proposes to fix HDF5 LZ4 filter not working with recent LZ4 implementation due to a wrong destination buffer size provided.
It also reworks the computation of the output buffer to account for the size being `nBlocks` times compression of block of `blockSize`.


closes #16