### PR TITLE
Fix typo in LZ4/src/lz4_h5filter.h

### DIFF
--- a/LZ4/src/lz4_h5filter.h
+++ b/LZ4/src/lz4_h5filter.h
@@ -17,7 +17,7 @@
 
 
 #ifndef LZ4_H5FILTER_H
-#define LZ5_H5FILTER_H
+#define LZ4_H5FILTER_H
 
 #define H5Z_class_t_vers 2
 #include "hdf5.h"


### PR DESCRIPTION
There is a typo in a `#define` in `LZ4/src/lz4_h5filter.h`