### PR TITLE
instead of creating long traces just print what is going wrong

### DIFF
--- a/LZ4/test/h5ex_d_lz4.c
+++ b/LZ4/test/h5ex_d_lz4.c
@@ -96,7 +96,11 @@ main (void)
         if ( (filter_config & H5Z_FILTER_CONFIG_ENCODE_ENABLED) && 
                 (filter_config & H5Z_FILTER_CONFIG_DECODE_ENABLED) ) 
             printf ("lz4 filter is available for encoding and decoding.\n");
-    }     
+    } else {
+        printf ("failed to set filter.\n");
+        goto done;
+    }
+
     status = H5Pset_chunk (dcpl_id, 2, chunk);
     if (status < 0) printf ("failed to set chunk.\n");
 


### PR DESCRIPTION
When the filter is not available, processing continues and will finally fail when writing data. As the resulting traces are not that clear it looks better when there is just one print saying what went wrong.